### PR TITLE
Display working directory, set title bar color

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "bradlc.vscode-tailwindcss",
+        "esbenp.prettier-vscode"
+    ]
+}

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2459,6 +2459,7 @@ dependencies = [
  "strip-ansi-escapes",
  "tauri",
  "tauri-build",
+ "windows 0.37.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,12 +18,12 @@ tauri-build = { version = "1.0.0-rc.12", features = [] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 tauri = { version = "1.0.0-rc.14", features = ["api-all"] }
-nu-engine = { git = "https://github.com/nushell/nushell", branch = "main", all-features = true}
-nu-protocol = { git = "https://github.com/nushell/nushell", branch = "main", all-features = true}
-nu-parser = { git = "https://github.com/nushell/nushell", branch = "main", all-features = true}
-nu-path = { git = "https://github.com/nushell/nushell", branch = "main", all-features = true}
-nu-command = { git = "https://github.com/nushell/nushell", branch = "main", all-features = true}
-nu-cli = { git = "https://github.com/nushell/nushell", branch = "main", all-features = true}
+nu-engine = { git = "https://github.com/nushell/nushell", branch = "main", all-features = true }
+nu-protocol = { git = "https://github.com/nushell/nushell", branch = "main", all-features = true }
+nu-parser = { git = "https://github.com/nushell/nushell", branch = "main", all-features = true }
+nu-path = { git = "https://github.com/nushell/nushell", branch = "main", all-features = true }
+nu-command = { git = "https://github.com/nushell/nushell", branch = "main", all-features = true }
+nu-cli = { git = "https://github.com/nushell/nushell", branch = "main", all-features = true }
 parking_lot = "0.12.0"
 strip-ansi-escapes = "0.1.1"
 regex = "1.5.5"
@@ -33,7 +33,16 @@ itertools = "0.10.3"
 [features]
 # by default Tauri runs in production mode
 # when `tauri dev` runs it is executed with `cargo run --no-default-features` if `devPath` is an URL
-default = [ "custom-protocol" ]
+default = ["custom-protocol"]
 # this feature is used used for production builds where `devPath` points to the filesystem
 # DO NOT remove this
-custom-protocol = [ "tauri/custom-protocol" ]
+custom-protocol = ["tauri/custom-protocol"]
+
+[target.'cfg(windows)'.dependencies.windows]
+version = "0.37.0"
+features = [
+    "alloc",
+    "Win32_Foundation",
+    "Win32_Graphics_Dwm",
+    "Win32_System_Registry",
+]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -10,21 +10,18 @@ use nu_protocol::{
     engine::{EngineState, Stack, StateWorkingSet},
     CliError, PipelineData, Span, Value,
 };
-use tauri::{command, Menu, MenuItem, State, Submenu};
+use tauri::{command, Manager, State};
 
 pub struct MyState {
     engine_state: Mutex<EngineState>,
     stack: Mutex<Stack>,
 }
 
-// #[derive(Debug, serde::Serialize)]
-// enum MyError {
-//     #[allow(dead_code)]
-//     FooError,
-// }
-
 mod nushell;
 mod run_external;
+
+#[cfg(target_os = "windows")]
+mod windows_utils;
 
 fn main() {
     let cwd = std::env::current_dir().unwrap();
@@ -54,35 +51,76 @@ fn main() {
             engine_state: Mutex::new(engine_state),
             stack: Mutex::new(stack),
         })
-        .invoke_handler(tauri::generate_handler![simple_command_with_result])
-        .menu(
-            Menu::new()
-                .add_submenu(Submenu::new(
-                    "Nushell",
-                    Menu::new()
-                        .add_native_item(MenuItem::EnterFullScreen)
-                        .add_native_item(MenuItem::Quit),
-                ))
-                .add_submenu(Submenu::new(
-                    "Edit",
-                    Menu::new()
-                        .add_native_item(MenuItem::Copy)
-                        .add_native_item(MenuItem::Paste)
-                        .add_native_item(MenuItem::Cut)
-                        .add_native_item(MenuItem::Undo)
-                        .add_native_item(MenuItem::Redo)
-                        .add_native_item(MenuItem::SelectAll),
-                )),
-        )
+        .invoke_handler(tauri::generate_handler![
+            simple_command_with_result,
+            get_working_directory
+        ])
+        // Disabling the menu to make the UI cleaner; can always re-enable it if we think of useful menu items to add
+        // .menu(
+        //     Menu::new()
+        //         .add_submenu(Submenu::new(
+        //             "Nushell",
+        //             Menu::new()
+        //                 .add_native_item(MenuItem::EnterFullScreen)
+        //                 .add_native_item(MenuItem::Quit),
+        //         ))
+        //         .add_submenu(Submenu::new(
+        //             "Edit",
+        //             Menu::new()
+        //                 .add_native_item(MenuItem::Copy)
+        //                 .add_native_item(MenuItem::Paste)
+        //                 .add_native_item(MenuItem::Cut)
+        //                 .add_native_item(MenuItem::Undo)
+        //                 .add_native_item(MenuItem::Redo)
+        //                 .add_native_item(MenuItem::SelectAll),
+        //         )),
+        // )
+        .setup(|app| {
+            if let Some(main_window) = app.get_window("main") {
+                try_set_titlebar_colors(&main_window);
+            }
+            Ok(())
+        })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+// Set the colors of the titlebar to match the current light/dark theme
+// TODO: pass in RGB colors as args, implement for more OSs, call this when OS theme changes
+fn try_set_titlebar_colors(window: &tauri::Window) {
+    #[cfg(target_os = "windows")]
+    {
+        use std::{ffi::c_void, mem::size_of};
+        use windows::Win32::Graphics::Dwm::{DwmSetWindowAttribute, DWMWA_CAPTION_COLOR};
+
+        // Note: this is a COLORREF, BGR (0x00bbggrr) not RGB
+        let bg_color = if windows_utils::is_dark_theme_active() {
+            0x00362b00 // Solarized Dark base03
+        } else {
+            0x00e3f6fd // Solarized Light base3
+        };
+
+        if let Ok(hwnd) = window.hwnd() {
+            let bg_ptr: *const i32 = &bg_color;
+            unsafe {
+                // Set titlebar background color
+                let _ = DwmSetWindowAttribute(
+                    hwnd,
+                    DWMWA_CAPTION_COLOR,
+                    bg_ptr as *const c_void,
+                    size_of::<i32>() as u32,
+                );
+                // TODO: set title text with DWMWA_TEXT_COLOR
+                // but the defaults of black+white are OK for now
+            }
+        }
+    }
 }
 
 #[command]
 fn simple_command_with_result(argument: String, state: State<MyState>) -> Result<String, String> {
     let mut engine_state = state.engine_state.lock();
     let mut stack = state.stack.lock();
-
     let result = nushell::eval_nushell(
         &mut engine_state,
         &mut stack,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -118,3 +118,15 @@ fn simple_command_with_result(argument: String, state: State<MyState>) -> Result
         }
     }
 }
+
+#[command]
+fn get_working_directory(state: State<MyState>) -> Result<String, String> {
+    let engine_state = state.engine_state.lock();
+    let stack = state.stack.lock();
+    let cwd = nu_engine::env::current_dir_str(&engine_state, &stack);
+
+    match cwd {
+        Ok(s) => Ok(s),
+        Err(e) => Ok(format!("\"{}\"", e)),
+    }
+}

--- a/src-tauri/src/windows_utils.rs
+++ b/src-tauri/src/windows_utils.rs
@@ -1,0 +1,49 @@
+use std::{ffi::OsString, os::windows::prelude::OsStrExt};
+use windows::{
+    core::PCWSTR,
+    Win32::{
+        Foundation::ERROR_SUCCESS,
+        System::Registry::{RegGetValueW, RRF_RT_REG_DWORD},
+    },
+};
+
+pub fn to_windows_wide_string(string: &str) -> Vec<u16> {
+    OsString::from(string)
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect()
+}
+
+// A port of Superluminal's C++ dark theme check: https://gist.github.com/rovarma/7b85f3db80f40cc144866812cad09919
+//
+// The Windows 10 Anniversary Update (1803) introduced support for dark mode. This is mainly intended for UWP apps, but things like Explorer follow it as well.
+// There is no API to query the value of this setting directly, but it is stored in the registry, so we can simply read it from there.
+// Note that if the regkey is not found in the registry (i.e. in earlier versions of Windows), we default to light theme.
+pub fn is_dark_theme_active() -> bool {
+    let hkey = windows::Win32::System::Registry::HKEY_CURRENT_USER;
+    let lpsubkey =
+        to_windows_wide_string("Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize");
+    let lpvalue = to_windows_wide_string("AppsUseLightTheme");
+    let mut pcbdata = std::mem::size_of::<u32>() as u32;
+    let mut pvdata: u32 = Default::default();
+
+    unsafe {
+        // Read value of the registry key; if it's 0 it means dark theme is enabled.
+        let res = RegGetValueW(
+            hkey,
+            PCWSTR(lpsubkey.as_ptr()),
+            PCWSTR(lpvalue.as_ptr()),
+            RRF_RT_REG_DWORD, // force RegGetValue to return a DWORD
+            std::ptr::null_mut(),
+            &mut pvdata as *mut u32 as *mut std::ffi::c_void,
+            &mut pcbdata,
+        );
+
+        if res == ERROR_SUCCESS {
+            return pvdata == 0;
+        }
+    }
+
+    // Regkey not found, default to light theme.
+    false
+}


### PR DESCRIPTION
This PR changes the card UI to display the working directory of each card in a tab. It also sets the title bar colour on Windows (can probably do this on other OSs too, but Windows is what I know) and removes the system menu*.

<img width="466" alt="image" src="https://user-images.githubusercontent.com/26268125/173170842-c80741c9-f347-4a3b-b0ba-a024d4b56dc5.png">
<img width="467" alt="image" src="https://user-images.githubusercontent.com/26268125/173170866-bd572e07-7aa8-400c-b085-1a0b40080438.png">

I've only tested this on Windows. Can try it out on Linux tomorrow, I don't expect anything to break though.

* The system menu was removed for aesthetic reasons; it's hard to theme on Windows and we weren't using it for anything important. Maybe we re-add it if we find a good use for it?