### PR TITLE
add autocapitalize = none

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -471,6 +471,7 @@
             >
                 <div id="header" class="flex">
                     <input
+                        autocapitalize="none"                          
                         class="input  w-full rounded-sm bg-solarized-base3 pl-2
                         font-mono text-solarized-base03 outline-none focus:ring-2 focus:ring-solarized-base0 dark:border-solarized-base02 
                         dark:bg-solarized-base03 dark:text-solarized-base3 dark:focus:ring-solarized-blue"


### PR DESCRIPTION
this is so the input edit box doesn't try to auto capitalize statements. previously, on Mac, if I did `ps<space>` it would make it `Ps `