### PR TITLE
Developer experience tweaks

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,15 @@
+set shell := ["nu", "-c"]
+
+setup:
+    yarn install
+
+watch:
+    yarn tauri dev
+
+# Build a release version of Nana
+build:
+    yarn tauri build --config `{ "tauri": { "bundle": { "active": false }}}`
+
+# Build release version and create an installer/package/bundle
+publish:
+    yarn tauri build --config `{ "tauri": { "bundle": { "active": true }}}`

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,13 +19,15 @@ serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 # enable devtools even in release mode; makes things easier for devs and we don't have a good reason to disable it
 tauri = { version = "1.0.0", features = ["api-all", "devtools"] }
-nu-engine = { git = "https://github.com/nushell/nushell", branch = "main", all-features = true }
-nu-protocol = { git = "https://github.com/nushell/nushell", branch = "main", all-features = true }
-nu-parser = { git = "https://github.com/nushell/nushell", branch = "main", all-features = true }
-nu-path = { git = "https://github.com/nushell/nushell", branch = "main", all-features = true }
-nu-command = { git = "https://github.com/nushell/nushell", branch = "main", all-features = true }
-nu-cli = { git = "https://github.com/nushell/nushell", branch = "main", all-features = true }
-reedline = { git = "https://github.com/nushell/reedline", branch = "main", features = ["bashisms"] }
+nu-engine = { git = "https://github.com/nushell/nushell", branch = "main" }
+nu-protocol = { git = "https://github.com/nushell/nushell", branch = "main" }
+nu-parser = { git = "https://github.com/nushell/nushell", branch = "main" }
+nu-path = { git = "https://github.com/nushell/nushell", branch = "main" }
+nu-command = { git = "https://github.com/nushell/nushell", branch = "main" }
+nu-cli = { git = "https://github.com/nushell/nushell", branch = "main" }
+reedline = { git = "https://github.com/nushell/reedline", branch = "main", features = [
+  "bashisms",
+] }
 parking_lot = "0.12.0"
 strip-ansi-escapes = "0.1.1"
 regex = "1.5.5"
@@ -44,8 +46,8 @@ custom-protocol = ["tauri/custom-protocol"]
 [target.'cfg(windows)'.dependencies.windows]
 version = "0.37.0"
 features = [
-    "alloc",
-    "Win32_Foundation",
-    "Win32_Graphics_Dwm",
-    "Win32_System_Registry",
+  "alloc",
+  "Win32_Foundation",
+  "Win32_Graphics_Dwm",
+  "Win32_System_Registry",
 ]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -11,7 +11,7 @@
     },
     "tauri": {
         "bundle": {
-            "active": true,
+            "active": false,
             "targets": "all",
             "identifier": "nushell.nana",
             "icon": [


### PR DESCRIPTION
A few small changes:
- Re-add the [justfile](https://github.com/casey/just) after it was removed in the React PR. I think tools like `just` and `make` are nicer than `package.json` scripts because they work for any programming language and JSON doesn't support comments
- Do _not_ create an installer/package/bundle by default when running `tauri build`. It takes a long time to create the installer when most of the time you just want to try the release-mode executable. Building with an installer is still easy, see the `publish` script in `justfile`
- Remove `all-features = true` from the Nu dependencies, this was generating a warning and not being used. If we really want to build with all features we can fix that up another time, but for now I think we might as well keep our dependencies lean so we can iterate faster
<img width="447" alt="image" src="https://user-images.githubusercontent.com/26268125/174854557-d3bd7791-66ab-49b4-9b72-579998c2a63f.png">
