### PR TITLE
Add card cache

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useReducer } from 'react';
-import { getWorkingDirectory } from '../support/nana';
+import { dropFromCache, getWorkingDirectory } from '../support/nana';
 import { randomId } from '../support/randomId';
 import { Card, CardPropTypes, ICard } from './Card';
 
@@ -40,7 +40,7 @@ const cardsReducer = (state: CardsState, action: CardsAction) => {
     case 'add':
       return [...state, action.card];
     case 'remove':
-      return state.filter((card) => card.id === action.cardId);
+      return state.filter((card) => card.id !== action.cardId);
     case 'update':
       return state.map((orig) => {
         if (orig.id === action.cardId) {
@@ -91,6 +91,7 @@ export const App = () => {
           history={history}
           onClose={() => {
             dispatchCards({ type: 'remove', cardId: card.id });
+            dropFromCache(card.id);
           }}
           onSubmit={(props: CardPropTypes, isError) => {
             handleSubmit(card.id, props, isError);

--- a/src/app/Card.tsx
+++ b/src/app/Card.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { FaTimes } from 'react-icons/fa';
 import { ansiFormat } from '../support/formatting';
-import { getWorkingDirectory } from '../support/nana';
+import { getWorkingDirectory, simpleCommandWithResult } from '../support/nana';
 import { Output } from './Output';
 import { Prompt } from './Prompt';
 
@@ -24,6 +24,7 @@ export const Card = (
   }
 ) => {
   const {
+    id,
     input,
     workingDir,
     history,
@@ -41,27 +42,28 @@ export const Card = (
 
   useEffect(resetActiveHistoryIndex, [history.length]);
 
-  const handleSubmit = async (out: string) => {
-    onSubmit(
-      {
-        input,
-        workingDir: await getWorkingDirectory(),
-        output: JSON.parse(out),
-      },
-      false
-    );
-    resetActiveHistoryIndex();
-  };
+  const handleSubmit = async () => {
+    try {
+      onSubmit(
+        {
+          input,
+          workingDir: await getWorkingDirectory(),
+          output: JSON.parse(await simpleCommandWithResult(id, input)),
+        },
+        false
+      );
+    } catch (error) {
+      onSubmit(
+        {
+          input,
+          workingDir: await getWorkingDirectory(),
+          output: ansiFormat(error as string),
+        },
+        true
+      );
+    }
 
-  const handleError = async (output: string) => {
-    onSubmit(
-      {
-        input,
-        workingDir: await getWorkingDirectory(),
-        output: ansiFormat(output),
-      },
-      true
-    );
+    resetActiveHistoryIndex();
   };
 
   const handleHistory = (delta: number) => {
@@ -90,7 +92,6 @@ export const Card = (
           <Prompt
             input={input ?? ''}
             onSubmit={handleSubmit}
-            onSubmitError={handleError}
             onHistoryUp={() => {
               handleHistory(-1);
             }}

--- a/src/app/Card.tsx
+++ b/src/app/Card.tsx
@@ -43,26 +43,17 @@ export const Card = (
   useEffect(resetActiveHistoryIndex, [history.length]);
 
   const handleSubmit = async () => {
+    const workingDir = await getWorkingDirectory();
+    let isError = false;
+    let output: string;
     try {
-      onSubmit(
-        {
-          input,
-          workingDir: await getWorkingDirectory(),
-          output: JSON.parse(await simpleCommandWithResult(id, input)),
-        },
-        false
-      );
+      output = JSON.parse(await simpleCommandWithResult(id, input));
     } catch (error) {
-      onSubmit(
-        {
-          input,
-          workingDir: await getWorkingDirectory(),
-          output: ansiFormat(error as string),
-        },
-        true
-      );
+        output = ansiFormat(error as string);
+        isError = true
     }
 
+    onSubmit({input, workingDir, output}, isError);
     resetActiveHistoryIndex();
   };
 

--- a/src/app/Prompt.tsx
+++ b/src/app/Prompt.tsx
@@ -1,5 +1,5 @@
 import { KeyboardEvent, useRef } from 'react';
-import { complete, simpleCommandWithResult } from '../support/nana';
+import { complete } from '../support/nana';
 
 export type ICompletion = {
   completion: string;
@@ -9,8 +9,7 @@ export type ICompletion = {
 type PromptPropType = {
   input: string;
   onInputChange: (input: string) => void;
-  onSubmit: (output: string) => void;
-  onSubmitError: (output: string) => void;
+  onSubmit: () => void;
   onHistoryUp: () => void;
   onHistoryDown: () => void;
 };
@@ -19,7 +18,6 @@ export const Prompt = ({
   input,
   onInputChange,
   onSubmit,
-  onSubmitError,
   onHistoryUp,
   onHistoryDown,
 }: PromptPropType) => {
@@ -46,12 +44,7 @@ export const Prompt = ({
 
   const handleSubmit = async () => {
     if (input.length > 0) {
-      try {
-        onSubmit(await simpleCommandWithResult(input));
-      } catch (err) {
-        onSubmitError(err as string);
-      } finally {
-      }
+        onSubmit();
     }
   };
 

--- a/src/support/nana.ts
+++ b/src/support/nana.ts
@@ -1,8 +1,9 @@
 import { invoke } from '@tauri-apps/api/tauri';
 import { ICompletion } from '../app/Prompt';
 
-export function simpleCommandWithResult(argument: string): Promise<string> {
+export function simpleCommandWithResult(cardId: string, argument: string): Promise<string> {
   return invoke('simple_command_with_result', {
+    cardId: cardId,
     argument: argument,
   });
 }
@@ -22,4 +23,8 @@ export function complete({
 
 export function getWorkingDirectory(): Promise<string> {
   return invoke('get_working_directory');
+}
+
+export function dropFromCache(cardId: string): Promise<void> {
+  return invoke('drop_card_from_cache', { cardId } );
 }


### PR DESCRIPTION
This change stores command results in a HashMap, and frees the cached results whenever a card is closed. Previously command results were not persisted in any way in the back-end. 

This cache is a building block for future features; we need to store command results to implement features like sorting.