### PR TITLE
Limit creating new card only with last card submit

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -74,10 +74,10 @@ export const App = () => {
     isError: boolean
   ) => {
     const cardIndex = cards.findIndex(({ id }) => id === cardId);
-    const isLast = cardIndex === cards.length;
+    const isLast = cardIndex === cards.length - 1;
 
     dispatchCards({ type: 'update', cardId, props });
-    if (!isLast) addEmptyCard();
+    if (isLast) addEmptyCard();
 
     dispatchHistory({ type: 'push', input: props.input });
   };


### PR DESCRIPTION
Regarding #52 

Currently new card is added to the bottom when submitted from top/middle cards. 
However, creating new card from last card's submit only seems useful. This PR will
add empty card only from last card's submit.

