### PR TITLE
Add sort indicator icon (arrow)

### DIFF
--- a/src/app/Output.tsx
+++ b/src/app/Output.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { FaLongArrowAltDown, FaLongArrowAltUp } from 'react-icons/fa';
 import {
   humanDuration,
   humanFileSize,
@@ -105,7 +106,15 @@ const List = ({
                   )
                 }
               >
-                {col}
+                <div className="relative">
+                  <span>{col}</span>
+                  {sortingOptions.column === col &&
+                    (sortingOptions.ascending ? (
+                      <FaLongArrowAltUp className="absolute top-0 bottom-0 right-0 my-auto self-center" />
+                    ) : (
+                      <FaLongArrowAltDown className="absolute top-0 bottom-0 right-0 my-auto self-center" />
+                    ))}
+                </div>
               </th>
             ))}
           </tr>


### PR DESCRIPTION
Previously there was no visual indicator that the grid had been sorted by a column.
![image](https://user-images.githubusercontent.com/26268125/177462460-75387ce1-9c91-42ec-8281-992dc5fb25cd.png)