### PR TITLE
Implement copy card button

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,8 +17,6 @@ tauri-build = { version = "1.0", features = [] }
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-# enable devtools even in release mode; makes things easier for devs and we don't have a good reason to disable it
-tauri = { version = "1.0", features = ["api-all", "devtools"] }
 nu-engine = { git = "https://github.com/nushell/nushell", branch = "main" }
 nu-protocol = { git = "https://github.com/nushell/nushell", branch = "main" }
 nu-parser = { git = "https://github.com/nushell/nushell", branch = "main" }
@@ -32,6 +30,8 @@ regex = "1.5.6"
 pathdiff = "0.2.1"
 itertools = "0.10.3"
 lscolors = "0.10.0"
+# enable devtools even in release mode; makes things easier for devs and we don't have a good reason to disable it
+tauri = {version = "1.0", features = ["api-all", "clipboard", "devtools"] }
 
 [features]
 # by default Tauri runs in production mode

--- a/src-tauri/src/nushell.rs
+++ b/src-tauri/src/nushell.rs
@@ -2,8 +2,12 @@ use nu_engine::eval_block;
 use nu_parser::parse;
 use nu_protocol::{
     engine::{EngineState, Stack, StateWorkingSet},
-    PipelineData, ShellError,
+    PipelineData, ShellError, Span, Value,
 };
+
+fn default_span() -> Span {
+    Span { start: 0, end: 0 }
+}
 
 pub fn eval_nushell(
     engine_state: &mut EngineState,
@@ -26,4 +30,47 @@ pub fn eval_nushell(
     }
 
     eval_block(engine_state, stack, &block, input, false, true)
+}
+
+/// Evaluate a block of Nu code, optionally with input.
+/// For example, source="$in * 2" will multiply the value in input by 2.
+pub fn simple_eval(
+    engine_state: &mut EngineState,
+    stack: &mut Stack,
+    input: Option<Value>,
+    source: &str,
+) -> Result<Value, ShellError> {
+    let (block, delta) = {
+        let mut working_set = StateWorkingSet::new(engine_state);
+        let (output, _) = parse(
+            &mut working_set,
+            Some("nana"),
+            source.as_bytes(),
+            false,
+            &[],
+        );
+
+        (output, working_set.render())
+    };
+
+    let cwd = nu_engine::env::current_dir_str(engine_state, stack)?;
+
+    if let Err(err) = engine_state.merge_delta(delta, Some(stack), &cwd) {
+        return Err(err);
+    }
+
+    let input_as_pipeline_data = match input {
+        Some(input) => PipelineData::Value(input, None),
+        None => PipelineData::new(default_span()),
+    };
+
+    eval_block(
+        engine_state,
+        stack,
+        &block,
+        input_as_pipeline_data,
+        false,
+        true,
+    )
+    .map(|x| x.into_value(default_span()))
 }

--- a/src/app/Card.tsx
+++ b/src/app/Card.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useState } from 'react';
-import { FaTimes } from 'react-icons/fa';
+import { FaCopy, FaTimes } from 'react-icons/fa';
 import { ansiFormat } from '../support/formatting';
 import {
+  copyCardToClipboard,
   getWorkingDirectory,
+  saveCard,
   simpleCommandWithResult,
   sortCardOutput,
 } from '../support/nana';
@@ -88,17 +90,31 @@ export const Card = (
 
   return (
     <div className="mb-2 flex flex-col">
-      <div className="mr-4 w-fit translate-y-1 self-end rounded-t bg-solarized-blue px-2 font-mono text-sm text-solarized-base2 dark:bg-solarized-base01">
-        <span>{workingDir}</span>
-        &nbsp;
-        <span onClick={onClose}>
-          <FaTimes className="inline cursor-pointer text-sm text-solarized-base3 hover:text-solarized-red dark:text-solarized-base03" />
-        </span>
+      <div
+        id="card-header"
+        className="flex w-full items-center justify-between rounded-t bg-solarized-blue px-2 py-1 font-mono text-sm text-solarized-base2 dark:bg-solarized-base01"
+      >
+        <div id="left-buttons" className="flex">
+          {output && (
+            <FaCopy
+              className="group ml-1 cursor-pointer text-xs hover:text-green-300"
+              title="Copy results to clipboard (as tab-separated values)"
+              onClick={async () => {
+                await copyCardToClipboard(id);
+              }}
+            />
+          )}
+        </div>
+        <div>{workingDir}</div>
+        <FaTimes
+          className="cursor-pointer text-solarized-base3 hover:text-solarized-red dark:text-solarized-base03"
+          onClick={onClose}
+        />
       </div>
 
       <div
         id="card-body"
-        className="rounded bg-solarized-blue px-2 pb-2 pt-2 dark:bg-solarized-base01"
+        className="rounded-b bg-solarized-blue px-2 pb-2 dark:bg-solarized-base01"
       >
         <div id="header" className="flex">
           <Prompt
@@ -115,7 +131,7 @@ export const Card = (
         </div>
 
         {output !== undefined && (
-          <div className="mt-2 rounded-sm border-solarized-base1 text-left font-mono text-sm text-solarized-base3 dark:border-solarized-base0 dark:bg-solarized-base02">
+          <div className="mt-2 border-solarized-base1 text-left font-mono text-sm text-solarized-base3 dark:border-solarized-base0 dark:bg-solarized-base02">
             <Output
               value={output}
               onSortOutput={(sortingOptions) => handleSortBy(sortingOptions)}

--- a/src/support/nana.ts
+++ b/src/support/nana.ts
@@ -39,3 +39,7 @@ export function sortCardOutput(
 ): Promise<string> {
   return invoke('sort_card', { cardId, sortColumn, ascending });
 }
+
+export function copyCardToClipboard(cardId: string): Promise<void> {
+  return invoke('copy_card_to_clipboard', { cardId });
+}


### PR DESCRIPTION
This PR adds a copy button to the top left of the card:

![image](https://user-images.githubusercontent.com/26268125/180917974-b0db9bb2-4fcc-49c4-8f40-4f35da34a0cd.png)

Clicking the button copies card results to the local clipboard in TSV (tab-separated) format, using Tauri's built-in clipboard API. I chose TSV because it's supported by Excel and Google Sheets - it's pretty cool to paste Nu data into a spreadsheet with a single `ctrl+V`!

![image](https://user-images.githubusercontent.com/26268125/180918283-f14b1ac9-23aa-47c8-a510-9241e04b6708.png)

## Future Work

- I'm not in love with the new design - the card header feels too bulky - but something had to change to allow for buttons in the top left. Please feel free to tweak the design, and I'll keep thinking about how to improve it.
- We should let users copy cards in other formats somehow. TSV/CSV aren't great with nested tables.
- Would be nice to be able to copy a card using the keyboard. But that would require a mechanism to select cards using the keyboard... 🤔