### PR TITLE
Remove debug code

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -83,11 +83,6 @@ fn main() {
             if let Some(main_window) = app.get_window("main") {
                 try_set_titlebar_colors(&main_window);
             }
-
-            let id = app.listen_global("ThemeChanged", |event| {
-                println!("got ThemeChanged with payload {:?}", event.payload());
-            });
-
             Ok(())
         })
         .run(tauri::generate_context!())


### PR DESCRIPTION
My bad, I accidentally included some debugging code in my last Nana PR.

Would be good to get `fmt` and `clippy` running in CI to catch things like this.