### PR TITLE
Implement save file functionality

### DIFF
--- a/src/app/Card.tsx
+++ b/src/app/Card.tsx
@@ -1,15 +1,24 @@
 import { useEffect, useState } from 'react';
-import { FaCopy, FaTimes } from 'react-icons/fa';
+import {
+  FaCopy,
+  FaDownload,
+  FaFile,
+  FaFileDownload,
+  FaRegSave,
+  FaSave,
+  FaTimes,
+} from 'react-icons/fa';
 import { ansiFormat } from '../support/formatting';
 import {
   copyCardToClipboard,
   getWorkingDirectory,
-  saveCard,
+  saveCardToFile,
   simpleCommandWithResult,
   sortCardOutput,
 } from '../support/nana';
 import { Output, SortingOptionsType } from './Output';
 import { Prompt } from './Prompt';
+import { message, save } from '@tauri-apps/api/dialog';
 
 export type CardPropTypes = {
   workingDir?: string;
@@ -96,13 +105,16 @@ export const Card = (
       >
         <div id="left-buttons" className="flex">
           {output && (
-            <FaCopy
-              className="group ml-1 cursor-pointer text-xs hover:text-green-300"
-              title="Copy results to clipboard (as tab-separated values)"
-              onClick={async () => {
-                await copyCardToClipboard(id);
-              }}
-            />
+            <>
+              <FaCopy
+                className="group ml-1 mr-2 cursor-pointer text-xs hover:text-green-300"
+                title="Copy results to clipboard (as tab-separated values)"
+                onClick={async () => {
+                  await copyCardToClipboard(id);
+                }}
+              />
+              <SaveFileButton cardID={id} />
+            </>
           )}
         </div>
         <div>{workingDir}</div>
@@ -140,5 +152,126 @@ export const Card = (
         )}
       </div>
     </div>
+  );
+};
+
+const SaveFileButton = ({ cardID }: { cardID: string }) => {
+  const [hover, setHover] = useState(false);
+
+  let hoverTimeoutId = 0;
+  const mouseEnter = () => {
+    clearTimeout(hoverTimeoutId);
+    setHover(true);
+  };
+  // short delay before closing the menu, to add some leeway in case the cursor briefly leaves the menu
+  const mouseLeave = () =>
+    (hoverTimeoutId = setTimeout(() => setHover(false), 100));
+
+  const handleItemClick = async (
+    nuFormatDisplayName: string,
+    nuFormat: string
+  ) => {
+    const filePath = await save({
+      filters: [
+        {
+          name: nuFormatDisplayName,
+          extensions: [nuFormat], // TODO: handle situation where Nu format differs from file extension?
+        },
+      ],
+    });
+
+    if (filePath) {
+      try {
+        await saveCardToFile(cardID, nuFormat, filePath);
+      } catch (error) {
+        await message(`Failed to save file: ${error}`, {
+          title: 'Error',
+          type: 'error',
+        });
+      }
+    }
+  };
+
+  const itemClasses =
+    'px-1 hover:bg-solarized-base2 dark:hover:bg-solarized-base0';
+
+  return (
+    <span
+      className="relative"
+      onMouseEnter={mouseEnter}
+      onMouseLeave={mouseLeave}
+    >
+      <FaFileDownload
+        title="Save card to disk"
+        className="hover:text-green-300"
+      />
+      <div
+        className={`absolute top-4 z-10 
+      cursor-pointer whitespace-nowrap rounded-md
+      border-4 border-solarized-base0 bg-solarized-base3 text-sm text-solarized-base03
+      drop-shadow-lg dark:border-solarized-base0 dark:bg-solarized-base03 dark:text-solarized-base3 ${
+        hover ? 'visible' : 'invisible'
+      }`}
+      >
+        <div
+          onClick={() => handleItemClick('CSV', 'csv')}
+          className={itemClasses}
+        >
+          CSV
+        </div>
+        <div
+          onClick={() => handleItemClick('HTML', 'html')}
+          className={itemClasses}
+        >
+          HTML
+        </div>
+        <div
+          onClick={() => handleItemClick('JSON', 'json')}
+          className={itemClasses}
+        >
+          JSON
+        </div>
+        <div
+          onClick={() => handleItemClick('Markdown', 'md')}
+          className={itemClasses}
+        >
+          Markdown
+        </div>
+        <div
+          onClick={() => handleItemClick('Nuon', 'nuon')}
+          className={itemClasses}
+          title="Nushell Object Notation"
+        >
+          Nuon
+        </div>
+        <div
+          onClick={() => handleItemClick('TOML', 'toml')}
+          className={itemClasses}
+        >
+          TOML
+        </div>
+        <div
+          onClick={() => handleItemClick('XML', 'xml')}
+          className={itemClasses}
+        >
+          XML
+        </div>
+        <div
+          onClick={() => handleItemClick('YAML', 'yaml')}
+          className={itemClasses}
+        >
+          YAML
+        </div>
+
+        {/* 
+        // judgment call: TSV isn't common enough to include by default
+        <div onClick={() => handleItemClick("TSV", "tsv")} className={itemClasses}>TSV</div>
+        // .text is awkward as a file extension. TODO implement a way to configure button with a .txt file extention
+        <div onClick={() => handleItemClick("Text", "text")} className={itemClasses}>Simple text</div>
+        // to xlsx isn't currently implemented/working on the Nu side
+        <div onClick={() => handleItemClick("Excel", "xlsx")} className={itemClasses}>Excel (XLSX)</div>
+      */}
+      </div>
+    </span>
   );
 };

--- a/src/app/Card.tsx
+++ b/src/app/Card.tsx
@@ -1,13 +1,5 @@
 import { useEffect, useState } from 'react';
-import {
-  FaCopy,
-  FaDownload,
-  FaFile,
-  FaFileDownload,
-  FaRegSave,
-  FaSave,
-  FaTimes,
-} from 'react-icons/fa';
+import { FaCopy, FaDownload, FaFile, FaFileDownload, FaRegSave, FaSave, FaTimes } from 'react-icons/fa';
 import { ansiFormat } from '../support/formatting';
 import {
   copyCardToClipboard,
@@ -38,16 +30,7 @@ export const Card = (
     onClose: () => void;
   }
 ) => {
-  const {
-    id,
-    input,
-    workingDir,
-    history,
-    output,
-    onClose,
-    onSubmit,
-    onInputChange,
-  } = props;
+  const { id, input, workingDir, history, output, onClose, onSubmit, onInputChange } = props;
 
   const [activeHistoryIndex, setActiveHistoryIndex] = useState(-1);
 
@@ -124,10 +107,7 @@ export const Card = (
         />
       </div>
 
-      <div
-        id="card-body"
-        className="rounded-b bg-solarized-blue px-2 pb-2 dark:bg-solarized-base01"
-      >
+      <div id="card-body" className="rounded-b bg-solarized-blue px-2 pb-2 dark:bg-solarized-base01">
         <div id="header" className="flex">
           <Prompt
             input={input ?? ''}
@@ -144,10 +124,7 @@ export const Card = (
 
         {output !== undefined && (
           <div className="mt-2 border-solarized-base1 text-left font-mono text-sm text-solarized-base3 dark:border-solarized-base0 dark:bg-solarized-base02">
-            <Output
-              value={output}
-              onSortOutput={(sortingOptions) => handleSortBy(sortingOptions)}
-            />
+            <Output value={output} onSortOutput={(sortingOptions) => handleSortBy(sortingOptions)} />
           </div>
         )}
       </div>
@@ -164,13 +141,9 @@ const SaveFileButton = ({ cardID }: { cardID: string }) => {
     setHover(true);
   };
   // short delay before closing the menu, to add some leeway in case the cursor briefly leaves the menu
-  const mouseLeave = () =>
-    (hoverTimeoutId = setTimeout(() => setHover(false), 100));
+  const mouseLeave = () => (hoverTimeoutId = setTimeout(() => setHover(false), 100));
 
-  const handleItemClick = async (
-    nuFormatDisplayName: string,
-    nuFormat: string
-  ) => {
+  const handleItemClick = async (nuFormatDisplayName: string, nuFormat: string) => {
     const filePath = await save({
       filters: [
         {
@@ -192,19 +165,11 @@ const SaveFileButton = ({ cardID }: { cardID: string }) => {
     }
   };
 
-  const itemClasses =
-    'px-1 hover:bg-solarized-base2 dark:hover:bg-solarized-base0';
+  const itemClasses = 'px-1 hover:bg-solarized-base2 dark:hover:bg-solarized-base0';
 
   return (
-    <span
-      className="relative"
-      onMouseEnter={mouseEnter}
-      onMouseLeave={mouseLeave}
-    >
-      <FaFileDownload
-        title="Save card to disk"
-        className="hover:text-green-300"
-      />
+    <span className="relative" onMouseEnter={mouseEnter} onMouseLeave={mouseLeave}>
+      <FaFileDownload title="Save card to disk" className="hover:text-green-300" />
       <div
         className={`absolute top-4 z-10 
       cursor-pointer whitespace-nowrap rounded-md
@@ -213,53 +178,28 @@ const SaveFileButton = ({ cardID }: { cardID: string }) => {
         hover ? 'visible' : 'invisible'
       }`}
       >
-        <div
-          onClick={() => handleItemClick('CSV', 'csv')}
-          className={itemClasses}
-        >
+        <div onClick={() => handleItemClick('CSV', 'csv')} className={itemClasses}>
           CSV
         </div>
-        <div
-          onClick={() => handleItemClick('HTML', 'html')}
-          className={itemClasses}
-        >
+        <div onClick={() => handleItemClick('HTML', 'html')} className={itemClasses}>
           HTML
         </div>
-        <div
-          onClick={() => handleItemClick('JSON', 'json')}
-          className={itemClasses}
-        >
+        <div onClick={() => handleItemClick('JSON', 'json')} className={itemClasses}>
           JSON
         </div>
-        <div
-          onClick={() => handleItemClick('Markdown', 'md')}
-          className={itemClasses}
-        >
+        <div onClick={() => handleItemClick('Markdown', 'md')} className={itemClasses}>
           Markdown
         </div>
-        <div
-          onClick={() => handleItemClick('Nuon', 'nuon')}
-          className={itemClasses}
-          title="Nushell Object Notation"
-        >
+        <div onClick={() => handleItemClick('Nuon', 'nuon')} className={itemClasses} title="Nushell Object Notation">
           Nuon
         </div>
-        <div
-          onClick={() => handleItemClick('TOML', 'toml')}
-          className={itemClasses}
-        >
+        <div onClick={() => handleItemClick('TOML', 'toml')} className={itemClasses}>
           TOML
         </div>
-        <div
-          onClick={() => handleItemClick('XML', 'xml')}
-          className={itemClasses}
-        >
+        <div onClick={() => handleItemClick('XML', 'xml')} className={itemClasses}>
           XML
         </div>
-        <div
-          onClick={() => handleItemClick('YAML', 'yaml')}
-          className={itemClasses}
-        >
+        <div onClick={() => handleItemClick('YAML', 'yaml')} className={itemClasses}>
           YAML
         </div>
 

--- a/src/support/nana.ts
+++ b/src/support/nana.ts
@@ -43,3 +43,11 @@ export function sortCardOutput(
 export function copyCardToClipboard(cardId: string): Promise<void> {
   return invoke('copy_card_to_clipboard', { cardId });
 }
+
+export function saveCardToFile(
+  cardId: string,
+  format: string,
+  filePath: string
+): Promise<void> {
+  return invoke('save_card', { cardId, format, filePath });
+}


### PR DESCRIPTION
Add a simple button and dropdown menu to save the contents of a card. Lots of screenshots:

![image](https://user-images.githubusercontent.com/26268125/189557360-1126b3a2-ad6d-4207-8ece-995359ad4a5d.png)

![image](https://user-images.githubusercontent.com/26268125/189557372-27d6b666-1b1a-4b15-8bf5-f59c409516b6.png)

![image](https://user-images.githubusercontent.com/26268125/189557376-14213eae-2d23-4a6f-9a56-0598ac4f383d.png)

We use the OS's native file picker and message box:

![image](https://user-images.githubusercontent.com/26268125/189557444-d5b03136-dd04-406b-9427-0abf260471ae.png)

![image](https://user-images.githubusercontent.com/26268125/189557397-98a7917e-57c9-4fa5-8085-2d005e563203.png)

## Future work

- Generalize the dropdown so we can use it for other things too?
- Add keyboard shortcut
    - will probably be a rabbit hole, haven't thought much about shortcuts yet