### PR TITLE
Track currently selected card, add keyboard shortcuts

### DIFF
--- a/src-tauri/src/nushell.rs
+++ b/src-tauri/src/nushell.rs
@@ -24,10 +24,7 @@ pub fn eval_nushell(
     };
 
     let cwd = nu_engine::env::current_dir_str(engine_state, stack)?;
-
-    if let Err(err) = engine_state.merge_delta(delta, Some(stack), &cwd) {
-        return Err(err);
-    }
+    engine_state.merge_delta(delta, Some(stack), &cwd)?;
 
     eval_block(engine_state, stack, &block, input, false, true)
 }
@@ -54,10 +51,7 @@ pub fn simple_eval(
     };
 
     let cwd = nu_engine::env::current_dir_str(engine_state, stack)?;
-
-    if let Err(err) = engine_state.merge_delta(delta, Some(stack), &cwd) {
-        return Err(err);
-    }
+    engine_state.merge_delta(delta, Some(stack), &cwd)?;
 
     let input_as_pipeline_data = match input {
         Some(input) => PipelineData::Value(input, None),

--- a/src/app/Card.tsx
+++ b/src/app/Card.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { FaCopy, FaDownload, FaFile, FaFileDownload, FaRegSave, FaSave, FaTimes } from 'react-icons/fa';
+import { FaCopy, FaFileDownload, FaTimes } from 'react-icons/fa';
 import { ansiFormat } from '../support/formatting';
 import {
   copyCardToClipboard,
@@ -25,12 +25,23 @@ export type ICard = CardPropTypes & {
 export const Card = (
   props: ICard & {
     history: string[];
+    selected: boolean;
+    onFocus?: () => void;
     onInputChange: (newInput: string) => void;
     onSubmit: (newProps: CardPropTypes, isError: boolean) => void;
     onClose: () => void;
   }
 ) => {
-  const { id, input, workingDir, history, output, onClose, onSubmit, onInputChange } = props;
+  const {
+    id,
+    input,
+    workingDir,
+    history,
+    output,
+    onClose,
+    onSubmit,
+    onInputChange,
+  } = props;
 
   const [activeHistoryIndex, setActiveHistoryIndex] = useState(-1);
 
@@ -80,17 +91,22 @@ export const Card = (
     }
   };
 
+  const selectedClasses = props.selected
+    ? 'bg-solarized-cyan dark:outline dark:outline-solarized-blue'
+    : 'bg-solarized-blue';
   return (
-    <div className="mb-2 flex flex-col">
+    <div
+      className={`mb-2 flex flex-col rounded  dark:bg-solarized-base01 ${selectedClasses}`}
+    >
       <div
         id="card-header"
-        className="flex w-full items-center justify-between rounded-t bg-solarized-blue px-2 py-1 font-mono text-sm text-solarized-base2 dark:bg-solarized-base01"
+        className="flex w-full items-center justify-between px-2 py-1 font-mono text-sm text-solarized-base2"
       >
-        <div id="left-buttons" className="flex">
+        <div id="left-buttons" className="flex space-x-2 pl-1">
           {output && (
             <>
               <FaCopy
-                className="group ml-1 mr-2 cursor-pointer text-xs hover:text-green-300"
+                className="group cursor-pointer text-xs hover:text-green-300"
                 title="Copy results to clipboard (as tab-separated values)"
                 onClick={async () => {
                   await copyCardToClipboard(id);
@@ -107,10 +123,12 @@ export const Card = (
         />
       </div>
 
-      <div id="card-body" className="rounded-b bg-solarized-blue px-2 pb-2 dark:bg-solarized-base01">
+      <div id="card-body" className="px-2 pb-2 ">
         <div id="header" className="flex">
           <Prompt
+            onFocus={props.onFocus}
             input={input ?? ''}
+            selected={props.selected}
             onSubmit={handleSubmit}
             onHistoryUp={() => {
               handleHistory(-1);
@@ -124,7 +142,10 @@ export const Card = (
 
         {output !== undefined && (
           <div className="mt-2 border-solarized-base1 text-left font-mono text-sm text-solarized-base3 dark:border-solarized-base0 dark:bg-solarized-base02">
-            <Output value={output} onSortOutput={(sortingOptions) => handleSortBy(sortingOptions)} />
+            <Output
+              value={output}
+              onSortOutput={(sortingOptions) => handleSortBy(sortingOptions)}
+            />
           </div>
         )}
       </div>
@@ -141,9 +162,13 @@ const SaveFileButton = ({ cardID }: { cardID: string }) => {
     setHover(true);
   };
   // short delay before closing the menu, to add some leeway in case the cursor briefly leaves the menu
-  const mouseLeave = () => (hoverTimeoutId = setTimeout(() => setHover(false), 100));
+  const mouseLeave = () =>
+    (hoverTimeoutId = setTimeout(() => setHover(false), 100));
 
-  const handleItemClick = async (nuFormatDisplayName: string, nuFormat: string) => {
+  const handleItemClick = async (
+    nuFormatDisplayName: string,
+    nuFormat: string
+  ) => {
     const filePath = await save({
       filters: [
         {
@@ -165,11 +190,19 @@ const SaveFileButton = ({ cardID }: { cardID: string }) => {
     }
   };
 
-  const itemClasses = 'px-1 hover:bg-solarized-base2 dark:hover:bg-solarized-base0';
+  const itemClasses =
+    'px-1 hover:bg-solarized-base2 dark:hover:bg-solarized-base0';
 
   return (
-    <span className="relative" onMouseEnter={mouseEnter} onMouseLeave={mouseLeave}>
-      <FaFileDownload title="Save card to disk" className="hover:text-green-300" />
+    <span
+      className="relative"
+      onMouseEnter={mouseEnter}
+      onMouseLeave={mouseLeave}
+    >
+      <FaFileDownload
+        title="Save card to disk"
+        className="hover:text-green-300"
+      />
       <div
         className={`absolute top-4 z-10 
       cursor-pointer whitespace-nowrap rounded-md
@@ -178,28 +211,53 @@ const SaveFileButton = ({ cardID }: { cardID: string }) => {
         hover ? 'visible' : 'invisible'
       }`}
       >
-        <div onClick={() => handleItemClick('CSV', 'csv')} className={itemClasses}>
+        <div
+          onClick={() => handleItemClick('CSV', 'csv')}
+          className={itemClasses}
+        >
           CSV
         </div>
-        <div onClick={() => handleItemClick('HTML', 'html')} className={itemClasses}>
+        <div
+          onClick={() => handleItemClick('HTML', 'html')}
+          className={itemClasses}
+        >
           HTML
         </div>
-        <div onClick={() => handleItemClick('JSON', 'json')} className={itemClasses}>
+        <div
+          onClick={() => handleItemClick('JSON', 'json')}
+          className={itemClasses}
+        >
           JSON
         </div>
-        <div onClick={() => handleItemClick('Markdown', 'md')} className={itemClasses}>
+        <div
+          onClick={() => handleItemClick('Markdown', 'md')}
+          className={itemClasses}
+        >
           Markdown
         </div>
-        <div onClick={() => handleItemClick('Nuon', 'nuon')} className={itemClasses} title="Nushell Object Notation">
+        <div
+          onClick={() => handleItemClick('Nuon', 'nuon')}
+          className={itemClasses}
+          title="Nushell Object Notation"
+        >
           Nuon
         </div>
-        <div onClick={() => handleItemClick('TOML', 'toml')} className={itemClasses}>
+        <div
+          onClick={() => handleItemClick('TOML', 'toml')}
+          className={itemClasses}
+        >
           TOML
         </div>
-        <div onClick={() => handleItemClick('XML', 'xml')} className={itemClasses}>
+        <div
+          onClick={() => handleItemClick('XML', 'xml')}
+          className={itemClasses}
+        >
           XML
         </div>
-        <div onClick={() => handleItemClick('YAML', 'yaml')} className={itemClasses}>
+        <div
+          onClick={() => handleItemClick('YAML', 'yaml')}
+          className={itemClasses}
+        >
           YAML
         </div>
 

--- a/src/app/Prompt.tsx
+++ b/src/app/Prompt.tsx
@@ -1,9 +1,11 @@
-import { forwardRef, KeyboardEvent, useRef, useState } from 'react';
+import { forwardRef, KeyboardEvent, useEffect, useRef, useState } from 'react';
 import { complete } from '../support/nana';
 import { CompletionList, ICompletion } from './CompletionList';
 
 type PromptPropType = {
   input: string;
+  selected: boolean;
+  onFocus?: () => void;
   onInputChange: (input: string) => void;
   onSubmit: () => void;
   onHistoryUp: () => void;
@@ -14,6 +16,8 @@ export const Prompt = forwardRef<HTMLDivElement, PromptPropType>(
   (
     {
       input,
+      selected,
+      onFocus,
       onInputChange: onChange,
       onSubmit,
       onHistoryUp,
@@ -24,6 +28,13 @@ export const Prompt = forwardRef<HTMLDivElement, PromptPropType>(
     const inputRef = useRef<HTMLInputElement>(null);
     const [completions, setCompletions] = useState<ICompletion[]>([]);
     const [activeCompletionIndex, setActiveCompletionIndex] = useState(0);
+
+    useEffect(() => {
+      if (selected) {
+        const input = inputRef.current!;
+        input.focus();
+      }
+    }, [selected]);
 
     const resetCompletions = () => {
       setCompletions([]);
@@ -99,6 +110,9 @@ export const Prompt = forwardRef<HTMLDivElement, PromptPropType>(
     };
 
     const handleKeyDown = (e: KeyboardEvent) => {
+      // avoid conflicts with higher-level shortcuts
+      if (e.ctrlKey) return;
+
       if (completions.length > 0) {
         switch (e.key) {
           case 'ArrowUp':
@@ -164,8 +178,9 @@ export const Prompt = forwardRef<HTMLDivElement, PromptPropType>(
           autoFocus
           autoCapitalize="none"
           type="text"
-          className="input m-0 w-full rounded-sm bg-solarized-base3 py-0 pl-2 font-mono text-solarized-base03 outline-none focus:ring-2 focus:ring-solarized-base0 dark:border-solarized-base02 dark:bg-solarized-base03 dark:text-solarized-base3 dark:focus:ring-solarized-blue"
+          className="input m-0 w-full rounded-sm bg-solarized-base3 py-0 pl-2 font-mono text-solarized-base03 outline-none focus:ring-2 focus:ring-solarized-blue dark:border-solarized-base02 dark:bg-solarized-base03 dark:text-solarized-base3 dark:focus:ring-solarized-blue"
           value={input ?? ''}
+          onFocus={onFocus}
           onKeyDown={handleKeyDown}
           onChange={(e) => {
             onChange(e.target.value);


### PR DESCRIPTION
This MR starts tracking the currently selected/focused card and adds some related keyboard shortcuts.

- Currently selected card is indicated with colours
- Can navigate between cards with `ctrl+up` and `ctrl+down`. Selected card also changes when a card's text input gets focus
- Can create a new card with `ctrl+n` and close the current card with `ctrl+w`

## Future work

- design tweaks; the colours I ended up with were a bit of a first draft
- macOS users will probably want to use `cmd` instead of `ctrl`, look into that
- make keyboard shortcuts documented+discoverable; maybe add a help window?
- more keyboard shortcuts!

## Screenshots

![image](https://user-images.githubusercontent.com/26268125/192154069-91b1778c-4d2e-4eaa-8549-f4654e48cc13.png)
![image](https://user-images.githubusercontent.com/26268125/192154085-1bc8bb32-4060-4341-9147-df94194dd9aa.png)
