### PR TITLE
Change `meta` shortcuts back to `ctrl` to fix on Windows

### DIFF
--- a/src-tauri/src/run_external.rs
+++ b/src-tauri/src/run_external.rs
@@ -457,8 +457,8 @@ impl ExternalCommand {
                     for m in matches {
                         if let Ok(arg) = m {
                             let arg = if let Some(prefix) = &prefix {
-                                if let Ok(remainder) = arg.strip_prefix(&prefix) {
-                                    let new_prefix = if let Some(pfx) = diff_paths(&prefix, &cwd) {
+                                if let Ok(remainder) = arg.strip_prefix(prefix) {
+                                    let new_prefix = if let Some(pfx) = diff_paths(prefix, &cwd) {
                                         pfx
                                     } else {
                                         prefix.to_path_buf()

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -84,10 +84,10 @@ export const App = () => {
 
   const deleteSelectedCard = () => deleteCard(cards[selectedCard]);
 
-  useShortcut('meta-up', decrementSelectedCard);
-  useShortcut('meta-down', incrementSelectedCard);
-  useShortcut('meta-w', deleteSelectedCard);
-  useShortcut('meta-n', addEmptyCard);
+  useShortcut('ctrl-up', decrementSelectedCard);
+  useShortcut('ctrl-down', incrementSelectedCard);
+  useShortcut('ctrl-w', deleteSelectedCard);
+  useShortcut('ctrl-n', addEmptyCard);
 
   useEffect(() => {
     if (cards.length === 0) addEmptyCard();

--- a/src/support/useShortcut.ts
+++ b/src/support/useShortcut.ts
@@ -1,48 +1,5 @@
 import { useEffect, useMemo, useRef } from 'react';
 
-type Meta = 'meta' | '';
-type Alt = 'alt' | '';
-type Shift = 'shift' | '';
-
-type Key =
-  | 'a'
-  | 'b'
-  | 'c'
-  | 'd'
-  | 'e'
-  | 'f'
-  | 'g'
-  | 'h'
-  | 'i'
-  | 'j'
-  | 'k'
-  | 'l'
-  | 'm'
-  | 'n'
-  | 'o'
-  | 'p'
-  | 'q'
-  | 'r'
-  | 's'
-  | 't'
-  | 'u'
-  | 'v'
-  | 'w'
-  | 'x'
-  | 'y'
-  | 'z'
-  | 'backspace'
-  | 'arrowleft'
-  | 'arrowright'
-  | 'arrowdown'
-  | 'arrowup';
-
-type Shortcut = `${Meta}-${Alt}-${Shift}-${Key}`;
-
-// Trying some type shenanigans to get typed shortcuts but it
-// doesn't quite work...
-const x: Shortcut = 'meta---a';
-
 // Aliases for various keyboard events, allowing shortcuts to be defined
 // using some more colloquial terms.
 const keyboardAliases: Record<string, string | undefined> = {
@@ -63,6 +20,7 @@ export interface ParsedShortcut {
   shiftKey: boolean;
   altKey: boolean;
   metaKey: boolean;
+  ctrlKey: boolean;
   key?: string;
 }
 
@@ -76,12 +34,14 @@ export function parseShortcut(shortcut: string) {
     shiftKey: false,
     altKey: false,
     metaKey: false,
+    ctrlKey: false,
   };
 
   for (const key of keys) {
     if (key === 'meta') parsed.metaKey = true;
     else if (key === 'alt') parsed.altKey = true;
     else if (key === 'shift') parsed.shiftKey = true;
+    else if (key === 'control') parsed.ctrlKey = true;
     else parsed.key = key.toLowerCase();
   }
   return parsed;
@@ -99,7 +59,8 @@ export function useShortcut(shortcut: string, fn: () => void) {
         event.key.toLowerCase() === parsedShortcut.key &&
         event.altKey === parsedShortcut.altKey &&
         event.metaKey === parsedShortcut.metaKey &&
-        event.shiftKey === parsedShortcut.shiftKey;
+        event.shiftKey === parsedShortcut.shiftKey &&
+        event.ctrlKey === parsedShortcut.ctrlKey;
 
       if (matches) fnRef.current();
     }


### PR DESCRIPTION
Noticed that the keyboard shortcuts weren't working on Windows after #72 (because the modifier was changed from `ctrl` to `meta`[^1]).

[^1]: `meta` seems to [map to the Command key on macOS, but surprisingly it does not map to the Windows key on Windows](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/metaKey).